### PR TITLE
Fixed Bug, Channel 1 was being mixed with the header byte

### DIFF
--- a/src/ibus/ibus.cpp
+++ b/src/ibus/ibus.cpp
@@ -28,7 +28,7 @@ void ibus::processIncoming() {
     _rxData[IBUS_MAX_PACKET_SIZE - 1] = _rxPort->read();
     if (_rxData[0] == IBUS_HEADER1 && _rxData[1] == IBUS_HEADER2) {
       if (checkSum()) {
-        _channelData.header = (_rxData[2] << 8) | _rxData[0];
+        _channelData.header = (_rxData[1] << 8) | _rxData[0];
         _channelData.channel1 = (_rxData[3] << 8) | _rxData[2];
         _channelData.channel2 = (_rxData[5] << 8) | _rxData[4];
         _channelData.channel3 = (_rxData[7] << 8) | _rxData[6];


### PR DESCRIPTION
There was a mistake in code where header was assigned the `LSB` of channel 1

## Original Code
```cpp
_channelData.header = (_rxData[2] << 8) | _rxData[0];
```

## Fixed COde
```cpp
_channelData.header = (_rxData[1] << 8) | _rxData[0];
```