### PR TITLE
Create example for ibus on RP2040

### DIFF
--- a/examples/rp2040/ibus_basic/.arduino-ci.yml
+++ b/examples/rp2040/ibus_basic/.arduino-ci.yml
@@ -1,0 +1,2 @@
+skip_files:
+  - ibus_basic.ino

--- a/examples/rp2040/ibus_basic/.arduino-ci.yml
+++ b/examples/rp2040/ibus_basic/.arduino-ci.yml
@@ -1,2 +1,18 @@
-skip_files:
-  - ibus_basic.ino
+platforms:
+  rpipico:
+    board: rp2040:rp2040:rpipico
+    package: rp2040:rp2040
+    gcc:
+      features:
+      defines:
+        - ARDUINO_ARCH_RP2040
+      warnings:
+      flags:
+
+packages:
+  rp2040:rp2040:
+    url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+
+compile:
+  platforms:
+    - rpipico

--- a/examples/rp2040/ibus_basic/ibus_basic.ino
+++ b/examples/rp2040/ibus_basic/ibus_basic.ino
@@ -30,8 +30,6 @@ ibus receiver(&Serial1, SBUS_RX_PIN, SBUS_TX_PIN,
 
 void setup() {
   // setup sbus receiver
-  Serial1.setInvertRX(true); // will only work with the earlephilhower core
-  Serial1.setInvertTX(true);
   receiver.begin();
 
   Serial.begin(115200);

--- a/examples/rp2040/ibus_basic/ibus_basic.ino
+++ b/examples/rp2040/ibus_basic/ibus_basic.ino
@@ -1,7 +1,8 @@
 /*!
- * @file crsf_basic.ino
+ * @file ibus_basic.ino
  */
 /*
+
 # Sample platformio.ini file:
 # ---------------------------
 [platformio]
@@ -17,16 +18,17 @@ monitor_speed = 115200
 lib_deps =
   https://github.com/Witty-Wizard/SerialIO
 */
+
 #include <SerialIO.h>
 
 #define SBUS_TX_PIN 0
 #define SBUS_RX_PIN 1
 
 rc_channels_t rcdata;
-ibus receiver(&Serial1, SBUS_RX_PIN, SBUS_TX_PIN, true); // RP2040 requires the TX_PIN so to not hang up the mcu
+ibus receiver(&Serial1, SBUS_RX_PIN, SBUS_TX_PIN,
+              true); // RP2040 requires the TX_PIN so to not hang up the mcu
 
-void setup()
-{
+void setup() {
   // setup sbus receiver
   Serial1.setInvertRX(true); // will only work with the earlephilhower core
   Serial1.setInvertTX(true);
@@ -35,19 +37,18 @@ void setup()
   Serial.begin(115200);
 }
 
-void loop()
-{
+void loop() {
   static unsigned long last_millis = millis();
 
   receiver.processIncoming();
   receiver.getChannel(&rcdata);
 
-  if (millis() > last_millis + 100)
-  {
+  if (millis() > last_millis + 100) {
     Serial.printf("RC: %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d",
-                  rcdata.channel1, rcdata.channel2, rcdata.channel3, rcdata.channel4,
-                  rcdata.channel5, rcdata.channel6, rcdata.channel7, rcdata.channel8,
-                  rcdata.channel9, rcdata.channel10, rcdata.channel11, rcdata.channel12,
+                  rcdata.channel1, rcdata.channel2, rcdata.channel3,
+                  rcdata.channel4, rcdata.channel5, rcdata.channel6,
+                  rcdata.channel7, rcdata.channel8, rcdata.channel9,
+                  rcdata.channel10, rcdata.channel11, rcdata.channel12,
                   rcdata.channel13, rcdata.channel14);
     Serial.println();
     last_millis = millis();

--- a/examples/rp2040/ibus_basic/ibus_basic.ino
+++ b/examples/rp2040/ibus_basic/ibus_basic.ino
@@ -1,0 +1,55 @@
+/*!
+ * @file crsf_basic.ino
+ */
+/*
+# Sample platformio.ini file:
+# ---------------------------
+[platformio]
+default_envs = ws-rp2040-zero
+
+[env:ws-rp2040-zero]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = waveshare_rp2040_pizero
+framework = arduino
+board_build.core = earlephilhower
+monitor_speed = 115200
+
+lib_deps =
+  https://github.com/Witty-Wizard/SerialIO
+*/
+#include <SerialIO.h>
+
+#define SBUS_TX_PIN 0
+#define SBUS_RX_PIN 1
+
+rc_channels_t rcdata;
+ibus receiver(&Serial1, SBUS_RX_PIN, SBUS_TX_PIN, true); // RP2040 requires the TX_PIN so to not hang up the mcu
+
+void setup()
+{
+  // setup sbus receiver
+  Serial1.setInvertRX(true); // will only work with the earlephilhower core
+  Serial1.setInvertTX(true);
+  receiver.begin();
+
+  Serial.begin(115200);
+}
+
+void loop()
+{
+  static unsigned long last_millis = millis();
+
+  receiver.processIncoming();
+  receiver.getChannel(&rcdata);
+
+  if (millis() > last_millis + 100)
+  {
+    Serial.printf("RC: %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d %4d",
+                  rcdata.channel1, rcdata.channel2, rcdata.channel3, rcdata.channel4,
+                  rcdata.channel5, rcdata.channel6, rcdata.channel7, rcdata.channel8,
+                  rcdata.channel9, rcdata.channel10, rcdata.channel11, rcdata.channel12,
+                  rcdata.channel13, rcdata.channel14);
+    Serial.println();
+    last_millis = millis();
+  }
+}


### PR DESCRIPTION
This commit adds an example how to use an ibus receiver with a RP2040 mcu.

## Related Issue
As discussed [here](https://github.com/Witty-Wizard/SerialIO/issues/26)

## Description
The example code includes a working minimal platformio.ini in form of a comment.

## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [x] Documentation update
- [ ] Other (specify): _______________

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
